### PR TITLE
Update composition-19-12

### DIFF
--- a/src/partials/composition.html
+++ b/src/partials/composition.html
@@ -22,6 +22,7 @@
                 <p class="composition-text">Aliquam ac dui vel dui vulputate consectetur. Mauris massa.</p>
             </li>
         </ul>
+
         <picture class="gallery-image">
             <source srcset="./images/desktop_photogallery_1x.jpg 1x, ./images/desktop_photogallery_2x.jpg 2x, ./images/desktop_photogallery_3x.jpg 3x" media="(min-width: 1280px)">
             <source srcset="./images/tablet_photogallery_1x.jpg 1x, ./images/tablet_photogallery_2x.jpg 2x, ./images/tablet_photogallery_3x.jpg 3x" media="(min-width: 740px)">
@@ -30,5 +31,5 @@
         </picture>
 
     </div>
-
+    <div class="composition-gap"></div>
 </section>

--- a/src/sass/layouts/_section-composition.scss
+++ b/src/sass/layouts/_section-composition.scss
@@ -5,13 +5,6 @@
 .composition {
     position: relative;
     background-color: $section-background;
-    /* margin-bottom: 80px;
-    @include for-size(tablet) {
-        margin-bottom: 121px;
-    }
-    @include for-size(desktop) {
-        margin-bottom: 123px;
-    } */
 }
 
 .composition-cards {

--- a/src/sass/layouts/_section-composition.scss
+++ b/src/sass/layouts/_section-composition.scss
@@ -3,9 +3,10 @@
 }
 
 .composition {
+    position: relative;
     background-color: $section-background;
-    /* margin-bottom: 80px; */
-    /* @include for-size(tablet) {
+    /* margin-bottom: 80px;
+    @include for-size(tablet) {
         margin-bottom: 121px;
     }
     @include for-size(desktop) {
@@ -17,15 +18,17 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    /* background-color: $section-background; */
+    margin-bottom: 150px;
     @include for-size(tablet) {
         display: flex;
         flex-direction: row;
         justify-content: flex-start;
         padding: 0 16px;
+        margin-bottom: 240px;
     }
     @include for-size(desktop) {
         padding: 0 95px;
+        margin-bottom: 305px;
     }
 }
 
@@ -37,6 +40,7 @@
     margin-bottom: 38px;
     @include for-size(tablet) {
         width: 180px;
+        margin-bottom: 0;
     }
     @include for-size(desktop) {
         width: 330px;
@@ -50,7 +54,7 @@
         }
     }
     &:last-child {
-        margin-bottom: 97px;
+        margin-bottom: 0px;
     }
     .composition-icon {
         display: block;
@@ -102,7 +106,27 @@
     }
 }
 
+.composition-gap {
+    width: 100%;
+    height: 73px;
+    background-color: $white-color;
+    @include for-size(tablet) {
+        height: 159px;
+    }
+    @include for-size(desktop) {
+        height: 260px;
+    }
+}
+
 .gallery-image {
     display: block;
+    position: absolute;
+    top: 648px;
     margin: 0;
+    @include for-size(tablet) {
+        top: 361px;
+    }
+    @include for-size(desktop) {
+        top: 361px;
+    }
 }


### PR DESCRIPTION
1) додав новий блок composition-gap, з білим бекграундом, щоб фіксити позицію фотки-галереї. Блок не входить в container і розтягується по 100% ширини. Адаптував його висоту до кожного дивайсу;
2) Відповідно задав нові маржини для composition;
3) абсолютно спозиціонував саму фотку.
Запропонував Amarel у слайдері зробити відступ від моєї секції паддінгами - додати до 
slider-container{
padding-top: 80px;
@include for-size(tablet) {
        padding-top: 121px;
    }
    @include for-size(desktop) {
        padding-top: 123px;
    }